### PR TITLE
Add OrderResultURL

### DIFF
--- a/Source/includes/helpers/ECPayPaymentHelper.php
+++ b/Source/includes/helpers/ECPayPaymentHelper.php
@@ -173,6 +173,7 @@ class ECPayPaymentHelper extends ECPayPaymentModuleHelper
         $this->sdk->EncryptType = $this->encryptType;
         $this->sdk->Send['ReturnURL'] = $inputs['returnUrl'];
         $this->sdk->Send['ClientBackURL'] = $this->filterUrl($inputs['clientBackUrl']);
+        $this->sdk->Send['OrderResultURL'] = $this->filterUrl($inputs['clientBackUrl']);
         $this->sdk->Send['MerchantTradeNo'] = $this->setMerchantTradeNo($inputs['orderId']);
         $this->sdk->Send['MerchantTradeDate'] = $this->getDateTime('Y/m/d H:i:s', '');
         $this->sdk->Send['TradeDesc'] = $this->getModuleDescription($inputs['cartName']);


### PR DESCRIPTION
讓預設行為改為直接轉回客戶的訂單完成頁, 以免 
Google Analytics, Facebook Pixel 等電商,廣告統計漏掉